### PR TITLE
UN-2022-66080

### DIFF
--- a/locodes/CM.csv
+++ b/locodes/CM.csv
@@ -40,3 +40,4 @@ CM,CMTKC,Tiko,Tiko,,1--4----,AI,,,
 CM,CMVIC,Victoria,Victoria,SW,--3-----,RQ,,0400N 00911E,
 CM,CMGXX,Yagoua,Yagoua,,---4----,RQ,,1021N 01514E,
 CM,CMYAO,Yaoundé,Yaounde,CE,---45---,AI,NSI,0352N 01131E,
+13,CM,CMNSI,Yaoundé Nsimalen International Apt,Yaoundé Nsimalen International Apt,CE,4.0,RQ,,0343N 01133E,"(HLAG) No UN/LOCODE for airport, use IATA Code. City is CMYAO",UN-2022-66080


### PR DESCRIPTION
Please consider the following change request to the UNLOCODE 
|    | Country   | locode   | NameRequested                      | NameRequested                      | SubdivisionRequested   |   FunctionRequested | Status   |   IATA | CoordinatesRequested   | UserRemarks                                                   | UNLogNumber   |
|---:|:----------|:---------|:-----------------------------------|:-----------------------------------|:-----------------------|--------------------:|:---------|-------:|:-----------------------|:--------------------------------------------------------------|:--------------|
| 13 | CM        | CMNSI    | Yaoundé Nsimalen International Apt | Yaoundé Nsimalen International Apt | CE                     |                   4 | RQ       |    nan | 0343N 01133E           | (HLAG) No UN/LOCODE for airport, use IATA Code. City is CMYAO | UN-2022-66080 |