### PR TITLE
UN-2022-66098

### DIFF
--- a/locodes/ES.csv
+++ b/locodes/ES.csv
@@ -4717,3 +4717,4 @@ ES,ESZRR,Zumárraga,Zumarraga,,--3-----,RL,,4305N 00219W,
 ES,ESZMY,Zumaya,Zumaya,,--3-----,RL,,,
 ES,ESZJA,Zurbaran,Zurbaran,,-----6--,RL,,3903N 00543W,
 ES,ESZRG,Zurgena,Zurgena,AL,--3-----,RL,,3721N 00202W,
+43,ES,ESAD3,Aldeacentenera,Aldeacentenera,CC,3.0,RQ,,3932N 00538W,,UN-2022-66098


### PR DESCRIPTION
Please consider the following change request to the UNLOCODE 
|    | Country   | locode   | NameRequested   | NameRequested   | SubdivisionRequested   |   FunctionRequested | Status   |   IATA | CoordinatesRequested   |   UserRemarks | UNLogNumber   |
|---:|:----------|:---------|:----------------|:----------------|:-----------------------|--------------------:|:---------|-------:|:-----------------------|--------------:|:--------------|
| 43 | ES        | ESAD3    | Aldeacentenera  | Aldeacentenera  | CC                     |                   3 | RQ       |    nan | 3932N 00538W           |           nan | UN-2022-66098 |

https://www.google.com/maps/place/10251+Aldeacentenera,+Cáceres,+Spain/@39.5270955,-5.6312647,16z/data=!4m5!3m4!1s0xd157345eb3d2bbd:0x379e0074c54be588!8m2!3d39.5266179!4d-5.6319946